### PR TITLE
Command to pull data for Markdown table

### DIFF
--- a/New-PSPowerHour.ps1
+++ b/New-PSPowerHour.ps1
@@ -88,7 +88,7 @@ $data | ForEach-Object {
         StandBy     = if ($sequence -gt 5) {"Yes"} else {"No"}
     }
     $sequence++
-} | Select-Object Order, IssueNumber, By, Title, StandBy ConvertTo-Markdown
+} | Select-Object Order, IssueNumber, By, Title, StandBy | ConvertTo-Markdown
 
 #ToDo
 # Order of columns is being messed with in the custom function to convert the table to markdown. Have not reviewed fully to get that straighted out

--- a/New-PSPowerHour.ps1
+++ b/New-PSPowerHour.ps1
@@ -1,0 +1,94 @@
+<#
+    .SYNOPSIS
+        Generate the markdown table of the presenters for the PSPowerHour
+    .NOTES
+        This utilizes PowerShellForGitHub module by the PowerShell team
+        For best results and the way written you will need a token from GitHub (no permissions needed to be assigned)
+#>
+[cmdletbinding()]
+param(
+    [string]$GitHubToken
+)
+
+function ConvertTo-Markdown {
+    <#
+    .SYNOPSIS
+        Converts a PowerShell object to a Markdown table.
+        https://mac-blog.org.ua/powershell-convertto-markdown/
+    .EXAMPLE
+        $data | ConvertTo-Markdown
+    .EXAMPLE
+        ConvertTo-Markdown($data)
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(
+            Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true
+        )]
+        [PSObject[]]$collection
+    )
+
+    Begin {
+        $items = @()
+        $columns = @{}
+    }
+
+    Process {
+        ForEach ($item in $collection) {
+            $items += $item
+
+            $item.PSObject.Properties | % {
+                if (-not $columns.ContainsKey($_.Name) -or $columns[$_.Name] -lt $_.Value.ToString().Length) {
+                    $columns[$_.Name] = $_.Value.ToString().Length
+                }
+            }
+        }
+    }
+
+    End {
+        ForEach ($key in $($columns.Keys)) {
+            $columns[$key] = [Math]::Max($columns[$key], $key.Length)
+        }
+
+        $header = @()
+        ForEach ($key in $columns.Keys) {
+            $header += ('{0,-' + $columns[$key] + '}') -f $key
+        }
+        $header -join ' | '
+
+        $separator = @()
+        ForEach ($key in $columns.Keys) {
+            $separator += '-' * $columns[$key]
+        }
+        $separator -join ' | '
+
+        ForEach ($item in $items) {
+            $values = @()
+            ForEach ($key in $columns.Keys) {
+                $values += ('{0,-' + $columns[$key] + '}') -f $item.($key)
+            }
+            $values -join ' | '
+        }
+    }
+}
+
+Import-Module PowerShellForGitHub
+$data = Get-GitHubIssueForRepository -repositoryUrl 'https://github.com/pspowerhour/pspowerhour' -gitHubAccessToken $GitHubToken |
+    Where-Object {$_.labels.name -eq 'proposal'} | Select-Object Number, Title, user | sort-object Number | select-object -first 10
+[int]$sequence = 1
+$data | ForEach-Object {
+    [PSCustomObject][ordered]@{
+        Order = "{0:00}" -f $sequence
+        IssueNumber = "#$($_.Number)"
+        By          = "@$($_.user.login)"
+        Title       = $_.Title
+        StandBy     = if ($sequence -gt 5) {"Yes"} else {"No"}
+    }
+    $sequence++
+} | Select-Object Order, IssueNumber, By, Title, StandBy ConvertTo-Markdown
+
+#ToDo
+# Order of columns is being messed with in the custom function to convert the table to markdown. Have not reviewed fully to get that straighted out

--- a/New-PSPowerHour.ps1
+++ b/New-PSPowerHour.ps1
@@ -9,21 +9,16 @@
 param(
     [string]$GitHubToken
 )
+$global:gitHubApiToken
+foreach ($m in 'PowerShellForGitHub', 'PSMarkdown') {
+    if (-not (Get-Module $m -ListAvailable)) {
+        throw "Please install $m module"
+    }
+    else {
+        Import-Module $m
+    }
+}
 
-if (-not (Get-Module PowerShellForGitHub)) {
-    Write-Output "Please install PowerShellForGitHub module!"
-}
-if (-not (Get-Module PSMarkdown -ListAvailable)) {
-    Write-Output "Please install PSMarkdown module!"
-}
-
-try {
-    Import-Module PowerShellForGitHub, PSMarkdown
-}
-catch {
-    Write-Warning "Issue loading modules"
-    $_
-}
 $data = Get-GitHubIssueForRepository -repositoryUrl 'https://github.com/pspowerhour/pspowerhour' -gitHubAccessToken $GitHubToken |
     Where-Object {$_.labels.name -eq 'proposal'} | Select-Object Number, Title, user | sort-object Number | select-object -first 10
 [int]$sequence = 1

--- a/New-PSPowerHour.ps1
+++ b/New-PSPowerHour.ps1
@@ -10,78 +10,26 @@ param(
     [string]$GitHubToken
 )
 
-function ConvertTo-Markdown {
-    <#
-    .SYNOPSIS
-        Converts a PowerShell object to a Markdown table.
-        https://mac-blog.org.ua/powershell-convertto-markdown/
-    .EXAMPLE
-        $data | ConvertTo-Markdown
-    .EXAMPLE
-        ConvertTo-Markdown($data)
-    #>
-    [CmdletBinding()]
-    [OutputType([string])]
-    param (
-        [Parameter(
-            Mandatory = $true,
-            Position = 0,
-            ValueFromPipeline = $true
-        )]
-        [PSObject[]]$collection
-    )
-
-    Begin {
-        $items = @()
-        $columns = @{}
-    }
-
-    Process {
-        ForEach ($item in $collection) {
-            $items += $item
-
-            $item.PSObject.Properties | % {
-                if (-not $columns.ContainsKey($_.Name) -or $columns[$_.Name] -lt $_.Value.ToString().Length) {
-                    $columns[$_.Name] = $_.Value.ToString().Length
-                }
-            }
-        }
-    }
-
-    End {
-        ForEach ($key in $($columns.Keys)) {
-            $columns[$key] = [Math]::Max($columns[$key], $key.Length)
-        }
-
-        $header = @()
-        ForEach ($key in $columns.Keys) {
-            $header += ('{0,-' + $columns[$key] + '}') -f $key
-        }
-        $header -join ' | '
-
-        $separator = @()
-        ForEach ($key in $columns.Keys) {
-            $separator += '-' * $columns[$key]
-        }
-        $separator -join ' | '
-
-        ForEach ($item in $items) {
-            $values = @()
-            ForEach ($key in $columns.Keys) {
-                $values += ('{0,-' + $columns[$key] + '}') -f $item.($key)
-            }
-            $values -join ' | '
-        }
-    }
+if (-not (Get-Module PowerShellForGitHub)) {
+    Write-Output "Please install PowerShellForGitHub module!"
+}
+if (-not (Get-Module PSMarkdown -ListAvailable)) {
+    Write-Output "Please install PSMarkdown module!"
 }
 
-Import-Module PowerShellForGitHub
+try {
+    Import-Module PowerShellForGitHub, PSMarkdown
+}
+catch {
+    Write-Warning "Issue loading modules"
+    $_
+}
 $data = Get-GitHubIssueForRepository -repositoryUrl 'https://github.com/pspowerhour/pspowerhour' -gitHubAccessToken $GitHubToken |
     Where-Object {$_.labels.name -eq 'proposal'} | Select-Object Number, Title, user | sort-object Number | select-object -first 10
 [int]$sequence = 1
 $data | ForEach-Object {
     [PSCustomObject][ordered]@{
-        Order = "{0:00}" -f $sequence
+        Order       = "{0:00}" -f $sequence
         IssueNumber = "#$($_.Number)"
         By          = "@$($_.user.login)"
         Title       = $_.Title
@@ -89,6 +37,3 @@ $data | ForEach-Object {
     }
     $sequence++
 } | Select-Object Order, IssueNumber, By, Title, StandBy | ConvertTo-Markdown
-
-#ToDo
-# Order of columns is being messed with in the custom function to convert the table to markdown. Have not reviewed fully to get that straighted out


### PR DESCRIPTION
Basic command that pulls the data for the following table format:

| Order | Issue Num | By | Title | Standby |
| --------- | -------- | ------- | -------- | ----- |
| 01 | #2 | @potatoqualitee | Default Parameter Values | No |
| 02 | #4 | @dfinke | The dime tour: PowerShell + Excel = Better Together | No |
| 03 | #5 | @mattcushing | Import Excel files to SQL Server in less than 20 lines of code, seriously!! | No |
| 04 | #6 | @awickham10 | Setting Trace Flags as Startup Parameters with dbatools | No |
| 05 | #7 | @jpomfret | Applying SQL Server Data Compression with dbatools | No |
| 06 | #8 | @alevyinroc | Better, Safer SQL Queries from PowerShell | No |
| 07 | #10 | @devblackops | ChatOps with Microsoft Teams and PoshBot | Yes |
| 08 | #11 | @Windos | Easy Desktop Notifications with BurntToast | Yes |
| 09 | #12 | @DanielSSilva | Raspberry Pi with powershell and IoT module | Yes |
| 10 | #13 | @wsmelton | Getting Started with Visual Studio Code | Yes |

Right off it does not order the output like above so something to work on further.