### PR TITLE
Add 2018-08-21 agenda

### DIFF
--- a/materials/2018-08-21/DanielSSilva/README.md
+++ b/materials/2018-08-21/DanielSSilva/README.md
@@ -1,0 +1,7 @@
+* **Name**: Daniel Silva
+* **Title**: Raspberry Pi with powershell and IoT module
+* **Abstract**: PowerShell on Raspberry opens a whole new world full of challenges. Check how you can interact with hardware using powershell and some examples of what you can achieve.
+
+* **Twitter**: @DanielSilv9
+* **SlackID**: @Danielsilva
+* **Blog**: https://danielsknowledgebase.wordpress.com/

--- a/materials/2018-08-21/README.md
+++ b/materials/2018-08-21/README.md
@@ -1,0 +1,15 @@
+# PowerHour 2018-08-21
+
+## Agenda
+
+Title                                                                                      | Name
+------------------------------------------------------------------------------------------ | ----------------------------------------------------
+[Default Parameter Values](potatoqualitee)                                                 | [Chrissy LeMaire](https://github.com/potatoqualitee)
+[The dime tour: PowerShell + Excel = Better Together](dfinke)                              | [Doug Finke](https://github.com/dfinke)
+[Import Excel files to SQL Server in less than 20 lines of code, seriously!!](mattcushing) | [Matt Cushing](https://github.com/mattcushing)
+[Setting Trace Flags as Startup Parameters with dbatools](awickham10)                      | [Andrew Wickham](https://github.com/awickham10)
+[Applying SQL Server Data Compression with dbatools](jpomfret)                             | [Jess Pomfret](https://github.com/jpomfret)
+[Better, Safer SQL Queries from PowerShell](alevyinroc)                                    | [Andy Levy](https://github.com/alevyinroc)
+[Easy Desktop Notifications with BurntToast](Windos)                                       | [Josh King](https://github.com/Windos)
+[Raspberry Pi with powershell and IoT module](DanielSSilva)                                | [Daniel Silva](https://github.com/DanielSSilva)
+

--- a/materials/2018-08-21/Windos/README.md
+++ b/materials/2018-08-21/Windos/README.md
@@ -1,0 +1,7 @@
+* **Name**: Josh King
+* **Title**: Easy Desktop Notifications with BurntToast
+* **Abstract**: Want to easily show notifications on your Windows 10 desktop? It's as easy as "cooking bread" with the [BurntToast](https://powershellgallery.com/packages/BurntToast) PowerShellmodule!
+
+* **Twitter**: @WindosNZ
+* **SlackID**: @windosnz
+* **Blog**: https://king.geek.nz/

--- a/materials/2018-08-21/alevyinroc/README.md
+++ b/materials/2018-08-21/alevyinroc/README.md
@@ -1,0 +1,7 @@
+* **Name**: Andy Levy
+* **Title**: Better, Safer SQL Queries from PowerShell
+* **Abstract**: If you're working with SQL Server from PowerShell, either as a DBA, analyst, or anyone else running queries, you've probably used Invoke-SqlCmd. But depending on how you're building your queries, this can be error-prone or a huge security exposure! With the help of the dbatools module, I'll show you how to write and run these queries better and safer - and make them easier to work into your scripts to boot.
+
+* **Twitter**: @alevyinroc
+* **SlackID**: @alevyinroc
+* **Blog**: https://therestisjustcode.wordpress.com/

--- a/materials/2018-08-21/awickham10/README.md
+++ b/materials/2018-08-21/awickham10/README.md
@@ -1,0 +1,5 @@
+* **Name**: Andrew Wickham
+* **Title**: Setting Trace Flags as Startup Parameters with dbatools
+* **Abstract**: How to set trace flags across your SQL Server landscape using the dbatool PowerShell module (Set-DbaStartupParameter and Enable-DbaTraceFlag functions)
+
+* **Twitter**: @awickham

--- a/materials/2018-08-21/dfinke/README.md
+++ b/materials/2018-08-21/dfinke/README.md
@@ -1,0 +1,7 @@
+* **Name**: Doug Finke
+* **Title**: The dime tour: PowerShell + Excel = Better Together
+* **Abstract**: A quick tour around my [PowerShell Excel module](https://www.powershellgallery.com/packages/ImportExcelhttps://www.powershellgallery.com/packages/ImportExcel) which lets you import/export Excel spreadsheets, without Excel being installed.
+
+* **Twitter**: @dfinke
+* **SlackID**: @dougfinke
+* **Blog**: https://dfinke.github.io/

--- a/materials/2018-08-21/jpomfret/README.md
+++ b/materials/2018-08-21/jpomfret/README.md
@@ -1,0 +1,7 @@
+* **Name**: Jess Pomfret
+* **Title**: Applying SQL Server Data Compression with dbatools
+* **Abstract**: Discover good candidates for row or page compression and then easily apply the recommended compression across your database.
+
+* **Twitter**: @jpomfret
+* **SlackID**: @jpomfret7
+* **Blog**: http://jesspomfret.com/

--- a/materials/2018-08-21/mattcushing/README.md
+++ b/materials/2018-08-21/mattcushing/README.md
@@ -1,0 +1,7 @@
+* **Name**: Matt Cushing
+* **Title**: Import Excel files to SQL Server in less than 20 lines of code, seriously!!
+* **Abstract**: How I went from being frustrated with SSIS handling Excel files, to importing things with ease using modules and scripts in Powershell. No PS experience necessary because I don't really have any either (yet)! With a hand from some great people, I went from banging myhead against the wall to writing simple, straightforward code with the help of Import-Excel and dbatools modules in PS.
+
+* **Twitter**: @sqlkohai
+* **SlackID**: @sqlkohai
+* **Blog**: http://sqlkohai.com/

--- a/materials/2018-08-21/potatoqualitee/README.md
+++ b/materials/2018-08-21/potatoqualitee/README.md
@@ -1,0 +1,6 @@
+* **Name**: Chrissy LeMaire
+* **Title**: Default Parameter Values
+* **Abstract**: $PSDefaultParameterValues are ultra useful for automation, scheduled tasks, and even docker but not a lot of people know about this feature. This 5 minute session will highlight the value of default parameter values and give real-world examples of how I usethem.
+
+* **Twitter**: @cl
+* **SlackID**: @cl


### PR DESCRIPTION
This is ~ 3/4 code generated, 1/4 grunt work.  Can probably eliminate most work...

* TODO: File issue to change issue template to yaml
* TODO: File issue to automate this.
  * PSMarkdown's ConvertTo-Markdown breaks any order of properties you feed it.  Some forks and alternatives should work
  * Clean up generated starter README.md's for each speaker (idea is speaker can add more - this just gets the basics in, but... odd spacing at the moment)
* TODO: File issue to add New-PowerHourProposal that:
  * Sanitizes things like twitter (@blah? twitter/blah?  blah?)
  * Uses Get-TimeZone (UTC offset allows error for DST, UTC + or - might get mixed up, etc.)
 
Maybe other stuff.  For now, should just get the agenda out if the hierarchy/linking works!