### PR TITLE
Change issue template to yaml, with notes

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,36 @@
-## Your Title Here
+Title: "Your Title"
+Name: "Your Name"
+Timezone: 'Output from `(Get-TimeZone).Id`'
+Abstract: |
+  A sentence or paragraph describing what you'll demo
+Twitter: 'Optional. Your Twitter @handle'
+SlackID: 'Optional. Your @name on [powershell.slack.com](bit.ly/psslack)'
+Blog: Optional. Blog URL
 
-* **Name**: Your Name
-* **Your Timezone**: Your [time offset](https://www.timeanddate.com/time/zones/) (e.g. `UTC +1`)
-* **Abstract**: A sentence or paragraph describing what you'll demo
-* Optional links (remove if not using)
-  * **Twitter**: Twitter profile URL
-  * **Slack ID**: Your @name on [powershell.slack.com](bit.ly/psslack)
-  * **Blog URL**: Blog URL
+#####################################################
+# IMPORTANT
+#   We parse this data as yaml
+#   Please use comments (#) for any other information
+# IMPORTANT
+# # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# Example proposal
+# ################
+# Title: "Dealing with Dependencies"
+# Name: "Warren Frame'
+# Timezone: 'America/New_York'
+# Abstract: |
+#   Managing dependencies is important.  As you start depending on published modules and libraries, ensuring you're using the expected version of a thing becomes critical!  We'll look at using PSDepend to help
+# Twitter: '@pscookiemonster'
+# SlackID: '@pscookiemonster'
+# Blog: 'https://ramblingcookiemonster.github.io/'
+
+# Notes
+#######
+# The quotation is intentional
+  # It helps with some common quotation that might cause issues (e.g. a ' in the title)
+  # Some guidelines [here](https://stackoverflow.com/a/22235064/3067642)
+# If you use a newline in your Abstract (do you need to?), indent the next line as well
+# Twitter, SlackID, and Blog are optional but help us and viewers find you!
+# If you don't specify Twitter or SlackID, be sure to keep track of your GitHub notifications!
+# Simple PowerShell function to generate this coming soon


### PR DESCRIPTION
This is pretty quick and dirty.  Open to any changes, would just prefer to move content to `yaml` to make automatically generating agendas and other data more straightforward