### PR TITLE
Add youtube link for powerhour 001

### DIFF
--- a/Agenda.md
+++ b/Agenda.md
@@ -1,5 +1,5 @@
 # PSPowerHour Agendas
 
-| Agenda
-| ------
-| [2018-08-21 6:00 PM EST](materials/2018-08-21)
+| Agenda | YouTube |
+| ------ | ------- |
+| [2018-08-21 6:00 PM EST](materials/2018-08-21) | [Video](https://www.youtube.com/watch?v=fDQvdIEda_c) |

--- a/materials/2018-08-21/README.md
+++ b/materials/2018-08-21/README.md
@@ -1,5 +1,7 @@
 # PowerHour 2018-08-21
 
+[Youtube](https://www.youtube.com/watch?v=fDQvdIEda_c)
+
 ## Agenda
 
 Title                                                                                      | Name


### PR DESCRIPTION
Unclear whether we need the video link on the Agenda.md page.  Convenient for now.  Can always remove later